### PR TITLE
regex now supports host aliases

### DIFF
--- a/github/github.ml
+++ b/github/github.ml
@@ -11,7 +11,7 @@ let get_current_repo () =
   let remote_origin = Core_unix.open_process_in command |> In_channel.input_all in
   let origin_regex =
     Str.regexp
-      {|\([^:]+\):\(github\.com\/\)?\(.+\)|}
+      {|\([^:]+\):\(\/\/github\.com\/\)?\(.+\)|}
   in
   assert (Str.string_match origin_regex remote_origin 0);
   let repo = Str.matched_group 3 remote_origin in

--- a/github/github.ml
+++ b/github/github.ml
@@ -11,10 +11,10 @@ let get_current_repo () =
   let remote_origin = Core_unix.open_process_in command |> In_channel.input_all in
   let origin_regex =
     Str.regexp
-      {|\(git@github\.com:\|https:\/\/github\.com\/\)\(.+\)|}
+      {|\([^:]+\):\(github\.com\/\)?\(.+\)|}
   in
   assert (Str.string_match origin_regex remote_origin 0);
-  let repo = Str.matched_group 2 remote_origin in
+  let repo = Str.matched_group 3 remote_origin in
   let repo = String.chop_suffix_if_exists repo ~suffix:".git" in
   let branch_cmd = "git rev-parse --abbrev-ref HEAD" in
   let branch = Core_unix.open_process_in branch_cmd |> In_channel.input_all in


### PR DESCRIPTION
I use a .ssh/config file for github cloning so git remote -v returns 'alias:reponame' instead of 'git@github.com:reponame'. Fixed the regex to account for this. I hope