### PR TITLE
respect `url.*.insteadOf` git config

### DIFF
--- a/github/github.ml
+++ b/github/github.ml
@@ -7,7 +7,7 @@ type t =
   }
 
 let get_current_repo () =
-  let command = "git config --get remote.origin.url" in
+  let command = "git remote get-url origin" in
   let remote_origin = Core_unix.open_process_in command |> In_channel.input_all in
   let origin_regex =
     Str.regexp


### PR DESCRIPTION
`git config` only returns the literal value of the remote, and doesn't expand it using the `insteadOf`[0] config, which can break the regex.

[0]: https://git-scm.com/docs/git-config#Documentation/git-config.txt-urlltbasegtinsteadOf